### PR TITLE
Filter requests

### DIFF
--- a/src/frontend/src/App.js
+++ b/src/frontend/src/App.js
@@ -1,6 +1,5 @@
 import './App.css';
 import React, {useState} from 'react';
-import Button from '@mui/material/Button';
 import WelcomePage from "./route/WelcomePage";
 import Requester from "./route/Requester";
 import Responder from "./route/Responder";

--- a/src/frontend/src/component/RequestList.css
+++ b/src/frontend/src/component/RequestList.css
@@ -22,9 +22,3 @@
     font-size: 16px;
     font-weight: bolder;
 }
-
-@media screen and (max-width: 600px) {
-    .RequestList {
-        height: 75vh;
-    }
-}

--- a/src/frontend/src/route/Dispatcher.js
+++ b/src/frontend/src/route/Dispatcher.js
@@ -14,7 +14,10 @@ const Dispatcher = () => {
     const [selectedResponder, setSelectedResponder] = useState('');
 
     useEffect(() => {
-        fetchRequests().then(res => setRequests(res.data));
+        fetchRequests("dispatcher").then(res => {
+            setRequests(res.data);
+            console.log(res);
+        });
     }, []);
 
     const assignResponder = async () => {

--- a/src/frontend/src/route/Dispatcher.js
+++ b/src/frontend/src/route/Dispatcher.js
@@ -18,10 +18,7 @@ const Dispatcher = () => {
     const [selectedResponder, setSelectedResponder] = useState("");
 
     useEffect(() => {
-        fetchRequests("dispatcher").then(res => {
-            setRequests(res.data);
-            console.log(res);
-        });
+        fetchRequests("dispatcher").then(res => setRequests(res.data));
     }, []);
 
     const assignResponderToSingle = async () => {

--- a/src/frontend/src/route/Requester.js
+++ b/src/frontend/src/route/Requester.js
@@ -5,8 +5,7 @@ import {
     FormControl,
     FormControlLabel,
     FormLabel, IconButton,
-    InputLabel,
-    MenuItem, Modal, Radio, RadioGroup,
+    MenuItem, Radio, RadioGroup,
     Select,
     TextField
 } from "@mui/material";
@@ -113,7 +112,7 @@ const Requester = () => {
                     <Button color="success" onClick={handleClickOpen}>View Details</Button>
                     <IconButton
                         color='success'
-                        onClick={()=>setAlert(false)}
+                        onClick={() => setAlert(false)}
                     >
                         <CloseIcon/>
                     </IconButton>
@@ -188,14 +187,12 @@ const Requester = () => {
                                             control={
                                                 <Controller
                                                     name="equipment"
-                                                    render={({}) => {
-                                                        return (
-                                                            <Checkbox
-                                                                checked={selectedItems.includes(option.label)}
-                                                                onChange={() => handleSelect(option.label)}
-                                                            />
-                                                        );
-                                                    }}
+                                                    render={() =>
+                                                        <Checkbox
+                                                            checked={selectedItems.includes(option.label)}
+                                                            onChange={() => handleSelect(option.label)}
+                                                        />
+                                                    }
                                                     control={control}
                                                 />
                                             }

--- a/src/frontend/src/route/Responder.js
+++ b/src/frontend/src/route/Responder.js
@@ -15,7 +15,7 @@ const Responder = () => {
     const [data, setData] = useState({});
 
     useEffect(() => {
-        fetchRequests().then(res => setRequests(res.data));
+        fetchRequests("responder").then(res => setRequests(res.data));
     }, []);
 
     const onViewClicked = (requestId) => {

--- a/src/frontend/src/route/WelcomePage.js
+++ b/src/frontend/src/route/WelcomePage.js
@@ -1,15 +1,9 @@
-
 import DustOff from "../images/Dustoff_Picture.jpeg"
 
-const WelcomePage = () => {
-    return(
-        <div className={"landing-page"}>
-
-            <h1 className={"welcome-title"}>9-Line Medevac</h1>
-
-            <img className={"full-size-img"} src={DustOff} alt={"Helicopter Picture"}></img>
-        </div>
-    )
-}
+const WelcomePage = () =>
+    <div className="landing-page">
+        <h1 className="welcome-title">9-Line Medevac</h1>
+        <img className="full-size-img" src={DustOff} alt="Helicopter landing in the desert"/>
+    </div>
 
 export default WelcomePage;

--- a/src/frontend/src/service/service.js
+++ b/src/frontend/src/service/service.js
@@ -8,8 +8,8 @@ export const submitForm = async (formData) => {
     return axios.post('/api/request', formData);
 }
 
-export const fetchRequests = async () => {
-    return await axios.get('/api/request');
+export const fetchRequests = async (role) => {
+    return await axios.get('/api/request', {headers: {Authorization: role}});
 }
 
 export const updateStatus = async (requestId) => {

--- a/src/main/java/com/teamb/nineline/controller/RequestController.java
+++ b/src/main/java/com/teamb/nineline/controller/RequestController.java
@@ -2,10 +2,8 @@ package com.teamb.nineline.controller;
 
 import com.teamb.nineline.exception.RequestExistsException;
 import com.teamb.nineline.model.Request;
-import com.teamb.nineline.repository.RequestRepository;
 import com.teamb.nineline.service.RequestService;
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,8 +22,8 @@ public class RequestController {
     }
 
     @GetMapping
-    private Iterable<Request> listAllRequests() {
-        return requestService.listRequests();
+    private Iterable<Request> getRequestsByRole(@RequestHeader String authorization) {
+        return requestService.getRequestsByRole(authorization);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/teamb/nineline/repository/RequestRepository.java
+++ b/src/main/java/com/teamb/nineline/repository/RequestRepository.java
@@ -4,4 +4,6 @@ import com.teamb.nineline.model.Request;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface RequestRepository extends PagingAndSortingRepository <Request, Long> {
+
+    Iterable<Request> findAllByResponder(String responder);
 }

--- a/src/main/java/com/teamb/nineline/service/RequestService.java
+++ b/src/main/java/com/teamb/nineline/service/RequestService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 public class RequestService {
 
     private static final String REQUEST_NOT_FOUND = "Request not found";
+    public static final String COMPLETE = "Complete";
+    public static final String DISPATCHER = "dispatcher";
 
     private RequestRepository requestRepository;
 
@@ -18,11 +20,12 @@ public class RequestService {
         return requestRepository.save(body);
     }
 
-    public Iterable<Request> listRequests(){return this.requestRepository.findAll();}
+    public Iterable<Request> getRequestsByRole(String role){
+        return this.requestRepository.findAllByResponder(role.equals(DISPATCHER) ? null : "Responder One");
+    }
 
     public Request getRequest(Long id) throws RequestExistsException {
-        Request request = requestRepository.findById(id).orElseThrow(() -> new RequestExistsException(REQUEST_NOT_FOUND));
-        return request;
+        return requestRepository.findById(id).orElseThrow(() -> new RequestExistsException(REQUEST_NOT_FOUND));
     }
     public Request updateRequestResponder(Long id, Request responder) throws RequestExistsException{
         Request request = requestRepository.findById(id).orElseThrow(() -> new RequestExistsException(REQUEST_NOT_FOUND));
@@ -32,7 +35,7 @@ public class RequestService {
 
     public Request updateStatus(Long id) throws RequestExistsException {
         Request request = requestRepository.findById(id).orElseThrow(() -> new RequestExistsException(REQUEST_NOT_FOUND));
-        request.setStatus("Complete");
+        request.setStatus(COMPLETE);
         return requestRepository.save(request);
     }
 }

--- a/src/test/java/com/teamb/nineline/controller/RequestControllerTest.java
+++ b/src/test/java/com/teamb/nineline/controller/RequestControllerTest.java
@@ -3,6 +3,7 @@ package com.teamb.nineline.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teamb.nineline.model.Request;
 import com.teamb.nineline.repository.RequestRepository;
+import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -25,6 +26,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 class RequestControllerTest {
+
+    public static final String DISPATCHER = "dispatcher";
+    public static final String RESPONDER = "responder";
+    public static final String AUTHORIZATION = "Authorization";
+
     @Autowired
     MockMvc mvc;
 
@@ -67,7 +73,7 @@ class RequestControllerTest {
     @Test
     @Transactional
     @Rollback
-    public void listRequest() throws Exception {
+    public void getRequestsByDispatcher() throws Exception {
         Request request1 = new Request();
         request1.setLocation("38STM1234567890");
         request1.setResponder(null);
@@ -102,13 +108,96 @@ class RequestControllerTest {
 
         this.requestRepository.save(request2);
 
-        MockHttpServletRequestBuilder request = get("/api/request");
+        Request request3 = new Request();
+        request3.setLocation("22STL2345678901");
+        request3.setResponder("Responder Two");
+        request3.setCallSign("humvee7");
+        request3.setTotalPatient(3);
+        request3.setPrecedence("urgent surgical");
+        request3.setEquipment("hoist");
+        request3.setAmbulatory(2);
+        request3.setLitter(0);
+        request3.setMarking("vs panel");
+        request3.setSecurity("clear");
+        request3.setNational("UK");
+        request3.setLine9("no nbc");
+        request3.setStatus(null);
+
+        this.requestRepository.save(request3);
+
+        MockHttpServletRequestBuilder request = get("/api/request")
+            .header(AUTHORIZATION,DISPATCHER);
+
+        String expected = objectMapper.writeValueAsString(Arrays.array(request1,request2));
 
         mvc.perform(request)
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].location", is("38STM1234567890")))
-                .andExpect(jsonPath("$[1].location", is("22STL2345678901")));
+                .andExpect(content().json(expected));
+    }
 
+    @Test
+    @Transactional
+    @Rollback
+    public void getRequestsByResponder() throws Exception {
+        Request request1 = new Request();
+        request1.setLocation("38STM1234567890");
+        request1.setResponder("Responder One");
+        request1.setCallSign("raptor1");
+        request1.setTotalPatient(3);
+        request1.setPrecedence("urgent");
+        request1.setEquipment("hoist");
+        request1.setAmbulatory(3);
+        request1.setLitter(0);
+        request1.setMarking("smoke");
+        request1.setSecurity("clear");
+        request1.setNational("US");
+        request1.setLine9("no nbc");
+        request1.setStatus(null);
+
+        this.requestRepository.save(request1);
+
+        Request request2 = new Request();
+        request2.setLocation("22STL2345678901");
+        request2.setResponder("Responder One");
+        request2.setCallSign("humvee7");
+        request2.setTotalPatient(3);
+        request2.setPrecedence("urgent surgical");
+        request2.setEquipment("hoist");
+        request2.setAmbulatory(2);
+        request2.setLitter(0);
+        request2.setMarking("vs panel");
+        request2.setSecurity("clear");
+        request2.setNational("UK");
+        request2.setLine9("no nbc");
+        request2.setStatus(null);
+
+        this.requestRepository.save(request2);
+
+        Request request3 = new Request();
+        request3.setLocation("22STL2345678901");
+        request3.setResponder("Responder Two");
+        request3.setCallSign("humvee7");
+        request3.setTotalPatient(3);
+        request3.setPrecedence("urgent surgical");
+        request3.setEquipment("hoist");
+        request3.setAmbulatory(2);
+        request3.setLitter(0);
+        request3.setMarking("vs panel");
+        request3.setSecurity("clear");
+        request3.setNational("UK");
+        request3.setLine9("no nbc");
+        request3.setStatus(null);
+
+        this.requestRepository.save(request3);
+
+        MockHttpServletRequestBuilder request = get("/api/request")
+                .header(AUTHORIZATION,RESPONDER);
+
+        String expected = objectMapper.writeValueAsString(Arrays.array(request1,request2));
+
+        mvc.perform(request)
+                .andExpect(status().isOk())
+                .andExpect(content().json(expected));
     }
 
     @Test


### PR DESCRIPTION
## Filter Requests by Role
### Back end
- updated `RequestController` get all requests endpoint to accept an `Authorization` header (also updated tests)
- updated `RequestService` to call a custom `findAllByResponder` query in `RequestRepository` to return a filtered list of requests based on the role specified in the `Authorization` header
- currently are hard coding all "responder" requests to return `Request`s for "Responder One" on the back end
### Front end
- updated both `Responder` page and `Dispatcher` page to fetchRequests with the appropriate header
- updated front end `Service` to set a header when fetching requests
